### PR TITLE
メッセージの非同期化（メッセージ送信実装も修正あり）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,81 @@
+$(function(){
+  function buildHTML(message){
+    if (message.image.url){
+      if (message.body && message.image.url) {
+        var html =
+        `<div class="mainchat__messages__message">
+          <div class="mainchat__messages__message__header">
+            <div class="mainchat__messages__message__header__user-name">
+              ${message.user_name}
+            </div>
+            <div class="mainchat__messages__message__header__day">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="mainchat__messages__message__content">
+            <p>${message.body}</p>
+            <img src=${message.image.url} >
+          </div>
+        </div>`
+      return html;
+      } else {
+        var html =
+        `<div class="mainchat__messages__message">
+          <div class="mainchat__messages__message__header">
+            <div class="mainchat__messages__message__header__user-name">
+              ${message.user_name}
+            </div>
+            <div class="mainchat__messages__message__header__day">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="mainchat__messages__message__content">
+            <img src=${message.image.url} >
+          </div>
+        </div>`
+      return html;
+      }
+      
+    } else {
+      var html =
+        `<div class="mainchat__messages__message">
+          <div class="mainchat__messages__message__header">
+            <div class="mainchat__messages__message__header__user-name">
+              ${message.user_name}
+            </div>
+            <div class="mainchat__messages__message__header__day">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="mainchat__messages__message__content">
+            ${message.body}
+          </div>
+        </div>`
+      return html;
+    };
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(message){
+      var html = buildHTML(message);
+      $('.mainchat__messages').append(html);
+      $('.mainchat__messages').animate({ scrollTop: $('.mainchat__messages')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.mainchat__messageform__content__send-btn').prop('disabled', false);
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
+  })
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -118,6 +118,7 @@ $text-color: #ffffff;
     width: 100%;
     background-color: #fafafa;
     padding: 35px 40px;
+    overflow: scroll;
     &__message {
       &__header {
         display: flex;
@@ -155,7 +156,6 @@ $text-color: #ffffff;
         width: 100%;
         background-color: $text-color;
         display: flex;
-        position: relative;
         &__text {
           height: 50px;
           width: 100%;
@@ -164,6 +164,7 @@ $text-color: #ffffff;
         &__icon {
           display: flex;
           align-items: center;
+          position: relative;
           &--image {
             position: absolute;
             right: 10px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,8 +9,11 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
+    
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,7 +8,7 @@ class Group < ApplicationRecord
   def show_last_message
     if (last_message = messages.last).present?
       if last_message.body?
-        last_message.body?
+        last_message.body
       else
         '画像が投稿されています'
       end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -30,7 +30,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Create different versions of your uploaded files:
   # version :thumb do
-    process resize_to_fit: [800, 800]
+    process resize_to_fit: [200, 200]
   # end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -14,10 +14,10 @@
     
     
   .mainchat__messageform
-    = form_for [@group, @message] ,html:{ class: 'mainchat__messageform__content' } do |f|
+    = form_for [@group, @message] , html:{ class: 'mainchat__messageform__content' } do |f|
       .mainchat__messageform__content__form-input
-        = f.text_field :body, class: 'mainchat__messageform__content__form-input__text', name: :message, placeholder: :"type a message"
+        = f.text_field :body, class: 'mainchat__messageform__content__form-input__text',placeholder: 'type a message'
         = f.label :image, class: 'mainchat__messageform__content__form-input__icon' do
-          = icon('fas', 'image', class: "mainchat__messageform__content__form-input__icon--image")
+          = icon('fas','image', class: 'mainchat__messageform__content__form-input__icon--image')
           = f.file_field :image, class: 'mainchat__messageform__content__form-input__icon--file'
-      = f.submit 'Send', class: 'mainchat__messageform__content__send-btn', name: :submit
+      = f.submit 'Send', class: 'mainchat__messageform__content__send-btn', name: 'submit'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -6,5 +6,6 @@
       = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   .mainchat__messages__message__content
     - if message.body.present?
-      = message.body
-    = image_tag message.image.url, if message.image.present?
+      %p= message.body
+    - if message.image.present?
+      = image_tag message.image.url

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.body @message.body
+json.image @message.image
+json.user_name @message.user.nickname
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/db/migrate/20200330102726_create_messages.rb
+++ b/db/migrate/20200330102726_create_messages.rb
@@ -1,7 +1,7 @@
 class CreateMessages < ActiveRecord::Migration[5.0]
   def change
     create_table :messages do |t|
-      t.text :body
+      t.string :body
       t.string :image
       t.references :group, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,12 +37,12 @@ ActiveRecord::Schema.define(version: 20200330102726) do
   end
 
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "body",       limit: 65535
+    t.string   "body"
     t.string   "image"
-    t.integer  "group_id",                 null: false
-    t.integer  "user_id",                  null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.integer  "group_id",   null: false
+    t.integer  "user_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
     t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end


### PR DESCRIPTION
# What
グループ内のチャット画面で行われるメッセージの投稿を非同期化した。
その際に、メッセージ送信実装の内容でもエラーが出ていたので修正した。

# Why
よく動くであろうチャット画面で毎回リロードをせずに投稿ができるようにするため。

メッセージ送信時↓
(文章だけ)
https://gyazo.com/e5f4b984f3641919964108f5ea33dd54
(文章と画像)
https://gyazo.com/87ad367fd19787d2b16ba411a9e603ea
(画像だけ)
https://gyazo.com/f18d11c1a89f1f4de7eb5ba3abdc30b3